### PR TITLE
Allow executing functions in attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/ezhlobo/eslint-plugin-react-pug",
   "bugs": "https://github.com/ezhlobo/eslint-plugin-react-pug/issues",
   "dependencies": {
-    "pug-uses-variables": "^0.0.4"
+    "pug-uses-variables": "^0.0.5"
   },
   "devDependencies": {
     "eslint": "^4.6.0",

--- a/tests/lib/rules/uses-vars.js
+++ b/tests/lib/rules/uses-vars.js
@@ -50,6 +50,22 @@ ruleTester.run('rule "uses-vars" (no-unused-vars)', ruleNoUnusedVars, {
         pug\`Component(boolean): Child\`
       `,
     },
+    {
+      code: `
+        /* eslint uses-vars: 1 */
+        export default () => {
+          const arg = ''
+          const scopeFunction = () => () => {}
+
+          return pug\`
+            button(
+              onClick=scopeFunction(arg)
+            )
+              | Scope Function
+          \`
+        }
+      `,
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Allow executing functions in attributes. Following code is not considered warning:

```jsx
export default () => {
  const arg = ''
  const scopeFunction = () => () => {}

  return pug`
    button(
      onClick=scopeFunction(arg)
    )
      | Scope Function
  `
}
```