### PR TITLE
Improve no broken template

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,5 +1,7 @@
 const { findVariablesInTemplate } = require('pug-uses-variables')
 
+const PLACEHOLDER = '__eslint-react-pug__'
+
 const getQuasiValue = ({ value }) => {
   if (value && typeof value === 'object') {
     return value.raw.trimRight()
@@ -13,7 +15,7 @@ const getInterpolatedTemplate = (template, interpolations) => template
     const rawValue = getQuasiValue(quasi)
 
     // We need to stringify interpolation so babel will understand the code
-    return interpolations[index] ? `${rawValue}` : rawValue
+    return interpolations[index] ? `${rawValue}"${PLACEHOLDER}"` : rawValue
   })
   .join('')
 

--- a/tests/lib/rules/no-broken-template.js
+++ b/tests/lib/rules/no-broken-template.js
@@ -35,6 +35,18 @@ ruleTester.run('rule "no-broken-template"', rule, {
           )
       \``,
     },
+    {
+      // eslint-disable-next-line no-template-curly-in-string
+      code: 'pug`div(className=${variable})`',
+    },
+    {
+      code: `
+        pug\`
+          div(className=\${false ? 'one' : 'two'})
+          div(className=\${true})
+        \`
+      `,
+    },
   ],
   invalid: [
     {

--- a/tests/lib/rules/no-undef.js
+++ b/tests/lib/rules/no-undef.js
@@ -60,6 +60,13 @@ ruleTester.run('rule "no-undef"', rule, {
         \`
       `,
     },
+    {
+      code: `/*global pug*//*eslint no-undef:1*/
+        pug\`
+          div(data-test=\${false ? 'one' : 'two'})
+        \`
+      `,
+    },
   ],
   invalid: [
     {

--- a/tests/lib/rules/uses-vars.js
+++ b/tests/lib/rules/uses-vars.js
@@ -118,6 +118,14 @@ ruleTester.run('rule "uses-vars" (no-unused-vars)', ruleNoUnusedVars, {
         \`
       `,
     },
+    {
+      code: `
+        /* eslint uses-vars: 1 */
+        pug\`
+          div(data-test=\${false ? 'one' : 'two'})
+        \`
+      `,
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
It adds a static string on the places where interpolation is used. It's necessary to allow parsing of templates, otherwise they are invalid.