### PR TITLE
Add the possibility to manage quotes in pug

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 /**
  * @fileoverview Add supporting of pugjs with react
- * @author
  */
 
 /* eslint-disable global-require */
 const allRules = {
   'no-broken-template': require('./lib/rules/no-broken-template'),
   'no-undef': require('./lib/rules/no-undef'),
+  quotes: require('./lib/rules/quotes'),
   'uses-react': require('./lib/rules/uses-react'),
   'uses-vars': require('./lib/rules/uses-vars'),
 }
@@ -22,6 +22,7 @@ module.exports = {
       rules: {
         'react-pug/no-broken-template': 2,
         'react-pug/no-undef': 2,
+        'react-pug/quotes': 2,
         'react-pug/uses-react': 2,
         'react-pug/uses-vars': 2,
       },

--- a/lib/rules/no-broken-template.js
+++ b/lib/rules/no-broken-template.js
@@ -3,8 +3,10 @@
  * @author Eugene Zhlobo
  */
 
-const { findVariablesInTemplate } = require('pug-uses-variables')
-const { isReactPugReference, getTemplate, buildLocation } = require('../utilities')
+const lexer = require('pug-lexer')
+
+const { isReactPugReference, buildLocation } = require('../util/eslint')
+const getTemplate = require('../util/getTemplate')
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -25,9 +27,8 @@ module.exports = {
       TaggedTemplateExpression: function (node) {
         if (isReactPugReference(node)) {
           const template = getTemplate(node)
-
           try {
-            findVariablesInTemplate(template)
+            lexer(template)
           } catch (error) {
             const line = (error.line + node.loc.start.line) - 1
             const source = error.src.split('\n')[error.line - 1]

--- a/lib/rules/no-undef.js
+++ b/lib/rules/no-undef.js
@@ -3,12 +3,9 @@
  * @author Eugene Zhlobo
  */
 
-const {
-  isReactPugReference,
-  getTemplate,
-  extractVariables,
-  buildLocation,
-} = require('../utilities')
+const { isReactPugReference, buildLocation } = require('../util/eslint')
+const getTemplate = require('../util/getTemplate')
+const getVariables = require('../util/getVariables')
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -42,7 +39,7 @@ module.exports = {
         if (isReactPugReference(node)) {
           const template = getTemplate(node)
 
-          const usedVariables = extractVariables(template)
+          const usedVariables = getVariables(template)
           const definedVariables = getDefinedVariables()
 
           const isVariableDefined = variable => !definedVariables.includes(variable.value)

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -1,0 +1,119 @@
+/**
+ * @fileoverview Manage quotes in Pug
+ * @author Eugene Zhlobo
+ */
+
+const { isReactPugReference, getTemplate, buildLocation } = require('../utilities')
+const lexer = require('pug-lexer')
+const { parse } = require('@babel/parser')
+const codeWalk = require('@babel/traverse').default
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const MESSAGE_DOUBLE = 'Strings must use double quotes'
+const MESSAGE_SINGLE = 'Code must use single quotes'
+
+const normalizeValue = token =>
+  `(${token.code || token.val})`
+
+const isStringValid = (string, singleQuote) => {
+  const check = singleQuote
+    ? /^'.*'$/
+    : /^".*"$/
+
+  return check.test(string)
+}
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Manage quotes in Pug',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    schema: [],
+  },
+
+  create: function (context) {
+    return {
+      TaggedTemplateExpression: function (node) {
+        if (isReactPugReference(node)) {
+          const withWrongQuotes = []
+
+          const template = getTemplate(node)
+          const tokens = lexer(template)
+
+          tokens.forEach((token) => {
+            const normalizedValue = normalizeValue(token)
+
+            if (
+              token.type === 'attribute' ||
+              token.type === 'code' ||
+              token.type === 'interpolated-code' ||
+              token.type === 'each'
+            ) {
+              const code = parse(normalizedValue)
+
+              codeWalk(code, {
+                StringLiteral(path) {
+                  const rawValue = path.node.extra.raw
+
+                  const doesNeedSingleQuote =
+                    // Object- or array-like
+                    /^({.*}|\[.*\])$/.test(token.code || token.val) ||
+                    // Code in template
+                    token.type === 'code' ||
+                    token.type === 'interpolated-code'
+
+                  if (isStringValid(rawValue, doesNeedSingleQuote)) {
+                    return false
+                  }
+
+                  const tokenStartAt = token.loc.start.column - 1
+                  const tokenEndAt = token.loc.end.column
+
+                  const tokenLine = template.split('\n').splice(token.loc.start.line - 1, 1)[0]
+                  const tokenSource = tokenLine.slice(tokenStartAt, tokenEndAt)
+
+                  const valueStartAt = tokenStartAt + tokenSource.indexOf(rawValue)
+                  const valueEndAt = valueStartAt + rawValue.length
+
+                  withWrongQuotes.push({
+                    singleQuote: doesNeedSingleQuote,
+                    loc: buildLocation(
+                      [token.loc.start.line, valueStartAt],
+                      [token.loc.end.line, valueEndAt],
+                    ),
+                  })
+
+                  return null
+                },
+              })
+            }
+          })
+
+          withWrongQuotes.forEach((variable) => {
+            const delta = variable.loc.start.line === 1
+              // When template starts plus backtick
+              ? node.quasi.quasis[0].loc.start.column + 1
+              : -1
+
+            const columnStart = variable.loc.start.column + delta
+            const columnEnd = variable.loc.end.column + delta
+
+            context.report({
+              node,
+              loc: buildLocation(
+                [(node.loc.start.line + variable.loc.start.line) - 1, columnStart + 1],
+                [(node.loc.start.line + variable.loc.end.line) - 1, columnEnd + 1],
+              ),
+              message: variable.singleQuote ? MESSAGE_SINGLE : MESSAGE_DOUBLE,
+            })
+          })
+        }
+      },
+    }
+  },
+}

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -3,10 +3,12 @@
  * @author Eugene Zhlobo
  */
 
-const { isReactPugReference, getTemplate, buildLocation } = require('../utilities')
-const lexer = require('pug-lexer')
 const { parse } = require('@babel/parser')
 const codeWalk = require('@babel/traverse').default
+
+const { isReactPugReference, buildLocation } = require('../util/eslint')
+const getTemplate = require('../util/getTemplate')
+const getTokens = require('../util/getTokens')
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -43,7 +45,7 @@ module.exports = {
           const withWrongQuotes = []
 
           const template = getTemplate(node)
-          const tokens = lexer(template)
+          const tokens = getTokens(template)
 
           tokens.forEach((token) => {
             const normalizedValue = normalizeValue(token)

--- a/lib/rules/uses-react.js
+++ b/lib/rules/uses-react.js
@@ -3,7 +3,7 @@
  * @author Eugene Zhlobo
  */
 
-const { isReactPugReference } = require('../utilities')
+const { isReactPugReference } = require('../util/eslint')
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/lib/rules/uses-vars.js
+++ b/lib/rules/uses-vars.js
@@ -3,7 +3,9 @@
  * @author Eugene Zhlobo
  */
 
-const { isReactPugReference, getTemplate, extractVariables } = require('../utilities')
+const { isReactPugReference } = require('../util/eslint')
+const getTemplate = require('../util/getTemplate')
+const getVariables = require('../util/getVariables')
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -25,7 +27,7 @@ module.exports = {
         if (isReactPugReference(node)) {
           const template = getTemplate(node)
 
-          extractVariables(template)
+          getVariables(template)
             .forEach(variable => context.markVariableAsUsed(variable.value))
         }
       },

--- a/lib/util/eslint.js
+++ b/lib/util/eslint.js
@@ -1,0 +1,22 @@
+function buildLocation(startCoord, endCoord) {
+  return {
+    start: {
+      line: startCoord[0],
+      column: startCoord[1],
+    },
+    end: {
+      line: endCoord[0],
+      column: endCoord[1],
+    },
+  }
+}
+
+function isReactPugReference({ tag }) {
+  return tag && tag.name === 'pug'
+}
+
+module.exports = {
+  buildLocation,
+
+  isReactPugReference,
+}

--- a/lib/util/getTemplate.js
+++ b/lib/util/getTemplate.js
@@ -1,5 +1,3 @@
-const { findVariablesInTemplate } = require('pug-uses-variables')
-
 const PLACEHOLDER = '__eslint-react-pug__'
 
 const getQuasiValue = ({ value }) => {
@@ -19,11 +17,7 @@ const getInterpolatedTemplate = (template, interpolations) => template
   })
   .join('')
 
-function isReactPugReference({ tag }) {
-  return tag && tag.name === 'pug'
-}
-
-function getTemplate({ quasi }) {
+module.exports = ({ quasi }) => {
   const { quasis, expressions } = quasi
 
   if (expressions && expressions.length) {
@@ -31,32 +25,4 @@ function getTemplate({ quasi }) {
   }
 
   return getQuasiValue(quasis[0])
-}
-
-function extractVariables(template) {
-  try {
-    return findVariablesInTemplate(template)
-  } catch (e) {
-    return []
-  }
-}
-
-function buildLocation(startCoord, endCoord) {
-  return {
-    start: {
-      line: startCoord[0],
-      column: startCoord[1],
-    },
-    end: {
-      line: endCoord[0],
-      column: endCoord[1],
-    },
-  }
-}
-
-module.exports = {
-  isReactPugReference,
-  getTemplate,
-  extractVariables,
-  buildLocation,
 }

--- a/lib/util/getTokens.js
+++ b/lib/util/getTokens.js
@@ -1,0 +1,9 @@
+const lexer = require('pug-lexer')
+
+module.exports = (template) => {
+  try {
+    return lexer(template)
+  } catch (error) {
+    return []
+  }
+}

--- a/lib/util/getVariables.js
+++ b/lib/util/getVariables.js
@@ -1,0 +1,9 @@
+const { findVariablesInTemplate } = require('pug-uses-variables')
+
+module.exports = (template) => {
+  try {
+    return findVariablesInTemplate(template)
+  } catch (error) {
+    return []
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint ./",
-    "test": "mocha tests --recursive"
+    "test": "mocha tests"
   },
   "files": [
     "LICENSE",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
   "homepage": "https://github.com/ezhlobo/eslint-plugin-react-pug",
   "bugs": "https://github.com/ezhlobo/eslint-plugin-react-pug/issues",
   "dependencies": {
+    "@babel/parser": "^7.0.0-rc.2",
+    "@babel/traverse": "^7.0.0-rc.2",
+    "pug-lexer": "^4.0.0",
     "pug-uses-variables": "^2.0.2"
   },
   "devDependencies": {

--- a/tests/lib/rules/quotes.js
+++ b/tests/lib/rules/quotes.js
@@ -27,8 +27,6 @@ const parserOptions = {
 
 const ruleTester = new RuleTester({ parserOptions })
 
-process.stdout.write('\033c\033[3J')
-
 const MESSAGE_PLAIN = 'Strings must use double quotes'
 const MESSAGE_CODE = 'Code must use single quotes'
 
@@ -152,7 +150,7 @@ ruleTester.run('rule "quotes"', rule, {
         column: 37,
         endLine: 3,
         endColumn: 42,
-      }]
+      }],
     },
     {
       code: `

--- a/tests/lib/rules/quotes.js
+++ b/tests/lib/rules/quotes.js
@@ -1,0 +1,225 @@
+/**
+ * @fileoverview Tests for quotes
+ * @author Eugene Zhlobo
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const eslint = require('eslint')
+
+const { RuleTester } = eslint
+
+const rule = require('../../../lib/rules/quotes')
+
+const parserOptions = {
+  ecmaVersion: 8,
+  sourceType: 'module',
+  ecmaFeatures: {
+    experimentalObjectRestSpread: true,
+  },
+}
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({ parserOptions })
+
+process.stdout.write('\033c\033[3J')
+
+const MESSAGE_PLAIN = 'Strings must use double quotes'
+const MESSAGE_CODE = 'Code must use single quotes'
+
+ruleTester.run('rule "quotes"', rule, {
+  valid: [
+    { code: 'pug`div(attr="hello")`' },
+    { code: 'pug`div(attr=test ? "one": "two")`' },
+    { code: 'pug`div(attr={ test: \'one\' })`' },
+    { code: 'pug`div(attr=[ \'one\' ])`' },
+    { code: 'pug`div(attr)`' },
+    { code: 'pug`div(attr=true)`' },
+    { code: 'pug`div(attr=false)`' },
+    { code: 'pug`div(...props)`' },
+    { code: 'pug`div= \'test\'`' },
+    {
+      code: `
+        pug\`
+          each item, index in [ 'one', 'two', 3, 'four' ]
+            p= item
+        \`
+      `,
+    },
+    {
+      code: `
+        pug\`
+          div 'Hello'
+          div "Hello"
+          div
+            | 'Hello'
+            | "Hello"
+        \`
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        pug\`div(attr= ' hello '  second=  ' hello ' )\`
+      `,
+      errors: [{
+        message: MESSAGE_PLAIN,
+        line: 2,
+        column: 24,
+        endLine: 2,
+        endColumn: 33,
+      }, {
+        message: MESSAGE_PLAIN,
+        line: 2,
+        column: 44,
+        endLine: 2,
+        endColumn: 53,
+      }],
+    },
+    {
+      code: `
+        pug\`div(attr= 1 + 'hello' + 1 )\`
+      `,
+      errors: [{
+        message: MESSAGE_PLAIN,
+        line: 2,
+        column: 28,
+        endLine: 2,
+        endColumn: 35,
+      }],
+    },
+    {
+      code: `
+        pug\`
+          div(attr= ' hello ' )
+        \`
+      `,
+      errors: [{
+        message: MESSAGE_PLAIN,
+        line: 3,
+        column: 21,
+        endLine: 3,
+        endColumn: 30,
+      }],
+    },
+    {
+      code: `
+        function Example() {
+          return pug\`div( attr= test ?  'one'  :  'two' || 'three' )\`
+        }
+      `,
+      errors: [{
+        message: MESSAGE_PLAIN,
+        line: 3,
+        column: 42,
+        endLine: 3,
+        endColumn: 47,
+      }, {
+        message: MESSAGE_PLAIN,
+        line: 3,
+        column: 52,
+        endLine: 3,
+        endColumn: 57,
+      }, {
+        message: MESSAGE_PLAIN,
+        line: 3,
+        column: 61,
+        endLine: 3,
+        endColumn: 68,
+      }],
+    },
+    {
+      code: `
+        pug\`
+          div(attr= test ? 'one' :  'two')
+        \`
+      `,
+      errors: [{
+        message: MESSAGE_PLAIN,
+        line: 3,
+        column: 28,
+        endLine: 3,
+        endColumn: 33,
+      }, {
+        message: MESSAGE_PLAIN,
+        line: 3,
+        column: 37,
+        endLine: 3,
+        endColumn: 42,
+      }]
+    },
+    {
+      code: `
+        pug\`div(attr={ test:  "one" })\`
+      `,
+      errors: [{
+        message: MESSAGE_CODE,
+        line: 2,
+        column: 32,
+        endLine: 2,
+        endColumn: 37,
+      }],
+    },
+    {
+      code: `
+        pug\`div(attr=[ "one" ])\`
+      `,
+      errors: [{
+        message: MESSAGE_CODE,
+        line: 2,
+        column: 25,
+        endLine: 2,
+        endColumn: 30,
+      }],
+    },
+    {
+      code: `
+        pug\`
+          div= "one"
+          div #{"one"}
+        \`
+      `,
+      errors: [{
+        message: MESSAGE_CODE,
+        line: 3,
+        column: 16,
+        endLine: 3,
+        endColumn: 21,
+      }, {
+        message: MESSAGE_CODE,
+        line: 4,
+        column: 17,
+        endLine: 4,
+        endColumn: 22,
+      }],
+    },
+    {
+      code: `
+        pug\`
+          each item, index in [ "one", "two" ]
+            p '#{item}'
+            p "#{item}"
+        \`
+      `,
+      errors: [{
+        message: MESSAGE_CODE,
+        line: 3,
+        column: 33,
+        endLine: 3,
+        endColumn: 38,
+      }, {
+        message: MESSAGE_CODE,
+        line: 3,
+        column: 40,
+        endLine: 3,
+        endColumn: 45,
+      }],
+    },
+  ],
+})


### PR DESCRIPTION
Add the rule to make double quotes required in all places inside the pug apart from javascript code. So:

```pug
div(attr="valid double quotes" + "another string")
```

But:

```pug
div(list=['one', 'two', 'three'])
```