### PR TITLE
Fix error location for single-line templates

### DIFF
--- a/lib/rules/no-undef.js
+++ b/lib/rules/no-undef.js
@@ -47,11 +47,19 @@ module.exports = {
           const notDefinedVariables = usedVariables.filter(isVariableDefined)
 
           notDefinedVariables.forEach((variable) => {
+            const delta = variable.loc.start.line === 1
+              // When template starts plus backtick
+              ? node.quasi.quasis[0].loc.start.column
+              : -1
+
+            const columnStart = variable.loc.start.column + delta
+            const columnEnd = variable.loc.end.column + delta
+
             context.report({
               node,
               loc: buildLocation(
-                [(node.loc.start.line + variable.loc.start.line) - 1, variable.loc.start.column],
-                [(node.loc.start.line + variable.loc.end.line) - 1, variable.loc.end.column],
+                [(node.loc.start.line + variable.loc.start.line) - 1, columnStart + 1],
+                [(node.loc.start.line + variable.loc.end.line) - 1, columnEnd + 1],
               ),
               message: `'${variable.value}' is not defined.`,
             })

--- a/tests/lib/rules/no-undef.js
+++ b/tests/lib/rules/no-undef.js
@@ -73,12 +73,20 @@ ruleTester.run('rule "no-undef"', rule, {
       code: '/*global pug*//*eslint no-undef:1*/ pug`App`;',
       errors: [{
         message: '\'App\' is not defined.',
+        line: 1,
+        column: 41,
+        endLine: 1,
+        endColumn: 44,
       }],
     },
     {
       code: '/*global pug*//*eslint no-undef:1*/ pug`= app`;',
       errors: [{
         message: '\'app\' is not defined.',
+        line: 1,
+        column: 43,
+        endLine: 1,
+        endColumn: 46,
       }],
     },
     {
@@ -92,6 +100,10 @@ ruleTester.run('rule "no-undef"', rule, {
       `,
       errors: [{
         message: '\'variable\' is not defined.',
+        line: 6,
+        column: 15,
+        endLine: 6,
+        endColumn: 23,
       }],
     },
     {
@@ -104,8 +116,16 @@ ruleTester.run('rule "no-undef"', rule, {
       `,
       errors: [{
         message: '\'upValue\' is not defined.',
+        line: 4,
+        column: 13,
+        endLine: 4,
+        endColumn: 20,
       }, {
         message: '\'upKey\' is not defined.',
+        line: 5,
+        column: 13,
+        endLine: 5,
+        endColumn: 18,
       }],
     },
   ],

--- a/tests/lib/rules/uses-react.js
+++ b/tests/lib/rules/uses-react.js
@@ -40,7 +40,13 @@ ruleTester.run('rule "uses-react"', ruleNoUnusedVars, {
   invalid: [
     {
       code: '/*eslint uses-react:1*/ var React;',
-      errors: [{ message: '\'React\' is defined but never used.' }],
+      errors: [{
+        message: '\'React\' is defined but never used.',
+        line: 1,
+        column: 29,
+        endLine: 1,
+        endColumn: 34,
+      }],
     },
   ],
 })

--- a/tests/lib/rules/uses-vars.js
+++ b/tests/lib/rules/uses-vars.js
@@ -135,7 +135,13 @@ ruleTester.run('rule "uses-vars" (no-unused-vars)', ruleNoUnusedVars, {
 
         pug\`div\`
       `,
-      errors: [{ message: '\'text\' is defined but never used.' }],
+      errors: [{
+        message: '\'text\' is defined but never used.',
+        line: 3,
+        column: 13,
+        endLine: 3,
+        endColumn: 17,
+      }],
     },
     {
       code: `
@@ -144,7 +150,13 @@ ruleTester.run('rule "uses-vars" (no-unused-vars)', ruleNoUnusedVars, {
 
         pug\`Component\`
       `,
-      errors: [{ message: '\'Child\' is defined but never used.' }],
+      errors: [{
+        message: '\'Child\' is defined but never used.',
+        line: 3,
+        column: 24,
+        endLine: 3,
+        endColumn: 29,
+      }],
     },
     {
       code: `
@@ -154,7 +166,13 @@ ruleTester.run('rule "uses-vars" (no-unused-vars)', ruleNoUnusedVars, {
 
         pug\`Component.Nested Plain text\`
       `,
-      errors: [{ message: '\'Nested\' is defined but never used.' }],
+      errors: [{
+        message: '\'Nested\' is defined but never used.',
+        line: 4,
+        column: 13,
+        endLine: 4,
+        endColumn: 19,
+      }],
     },
     {
       code: `
@@ -169,6 +187,9 @@ ruleTester.run('rule "uses-vars" (no-unused-vars)', ruleNoUnusedVars, {
       errors: [{
         message: '\'HelloMessage\' is defined but never used.',
         line: 3,
+        column: 15,
+        endLine: 3,
+        endColumn: 27,
       }],
     },
     {
@@ -184,6 +205,9 @@ ruleTester.run('rule "uses-vars" (no-unused-vars)', ruleNoUnusedVars, {
       errors: [{
         message: '\'Hello\' is defined but never used.',
         line: 3,
+        column: 17,
+        endLine: 3,
+        endColumn: 22,
       }],
     },
     {
@@ -201,6 +225,9 @@ ruleTester.run('rule "uses-vars" (no-unused-vars)', ruleNoUnusedVars, {
       errors: [{
         message: '\'item\' is assigned a value but never used.',
         line: 3,
+        column: 15,
+        endLine: 3,
+        endColumn: 19,
       }],
     },
     {
@@ -219,6 +246,9 @@ ruleTester.run('rule "uses-vars" (no-unused-vars)', ruleNoUnusedVars, {
       errors: [{
         message: '\'variable\' is assigned a value but never used.',
         line: 3,
+        column: 15,
+        endLine: 3,
+        endColumn: 23,
       }],
     },
   ],


### PR DESCRIPTION
Fix #23 

This used to provide incorrect location in eslint reports. It's fixed now.

```jsx
const Hello = () => pug`div Test`
```