### PR TITLE
Require single quotes inside "each" context

### DIFF
--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -69,6 +69,7 @@ module.exports = {
                     // Code in template
                     || token.type === 'code'
                     || token.type === 'interpolated-code'
+                    || token.type === 'each'
                   )
 
                   if (isStringValid(rawValue, doesNeedSingleQuote)) {

--- a/tests/lib/rules/quotes.js
+++ b/tests/lib/rules/quotes.js
@@ -57,6 +57,14 @@ ruleTester.run('rule "quotes"', rule, {
         \`
       `,
     },
+    {
+      code: `
+        pug\`
+          each item in Array(10).fill('one')
+            p Hello
+        \`
+      `,
+    },
   ],
   invalid: [
     {
@@ -214,6 +222,21 @@ ruleTester.run('rule "quotes"', rule, {
         column: 40,
         endLine: 3,
         endColumn: 45,
+      }],
+    },
+    {
+      code: `
+        pug\`
+          each item in Array(10).fill("one")
+            p Hello
+        \`
+      `,
+      errors: [{
+        message: MESSAGE_CODE,
+        line: 3,
+        column: 39,
+        endLine: 3,
+        endColumn: 44,
       }],
     },
   ],


### PR DESCRIPTION
It fixes the issue when it required double quotes inside `each` declarations.

Request: #42