### PR TITLE
Lint JavaScript in Pug by providing eslint interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Then configure the rules you want to use under the rules section.
 ## List of supported rules
 
 * [`react-pug/empty-lines`](./docs/rules/empty-lines.md): Manage empty lines in Pug
+* [`react-pug/eslint`](./docs/rules/eslint.md): Lint JavaScript code inside Pug
 * [`react-pug/indent`](./docs/rules/indent.md): Enforce consistent indentation
 * [`react-pug/no-broken-template`](./docs/rules/no-broken-template.md): Disallow broken template
 * [`react-pug/no-interpolation`](./docs/rules/no-interpolation.md): Disallow JavaScript interpolation

--- a/docs/rules/eslint.md
+++ b/docs/rules/eslint.md
@@ -1,0 +1,33 @@
+# Lint JavaScript code inside Pug (react-pug/eslint)
+
+This rule applies eslint to JavaScript code used in Pug.
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```jsx
+/*eslint react-pug/eslint: ["error", { "comma-spacing": "error" }]*/
+pug`div(data-value=getValueFor(one,two,three))`
+```
+
+```jsx
+/*eslint react-pug/eslint: ["error", { "no-multi-spaces": "error" }]*/
+pug`div(data-value=getValueFor(one,two,three,  four,   five))`
+```
+
+The following patterns are **not** considered warnings:
+
+```jsx
+/*eslint react-pug/eslint: ["error", { "comma-spacing": "error" }]*/
+pug`div(data-value=getValueFor(one, two, three))`
+```
+
+```jsx
+/*eslint react-pug/eslint: ["error", { "no-multi-spaces": "error" }]*/
+pug`div(data-value=getValueFor(one,two,three, four, five))`
+```
+
+## When Not To Use It
+
+If you don't won't to apply eslint rules to the javascript inside Pug.

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@
 /* eslint-disable global-require */
 const allRules = {
   'empty-lines': require('./lib/rules/empty-lines'),
+  eslint: require('./lib/rules/eslint'),
   indent: require('./lib/rules/indent'),
   'no-broken-template': require('./lib/rules/no-broken-template'),
   'no-interpolation': require('./lib/rules/no-interpolation'),

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ module.exports = {
       },
       rules: {
         'react-pug/empty-lines': 2,
+        'react-pug/eslint': 2,
         'react-pug/indent': 2,
         'react-pug/no-broken-template': 2,
         'react-pug/no-undef': 2,

--- a/lib/rules/eslint.js
+++ b/lib/rules/eslint.js
@@ -1,0 +1,112 @@
+/**
+ * @fileoverview Lint JavaScript code inside Pug
+ * @author Eugene Zhlobo
+ */
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { Linter } = require('eslint')
+
+const { isReactPugReference, buildLocation, docsUrl } = require('../util/eslint')
+const getTemplate = require('../util/getTemplate')
+const getTokens = require('../util/getTokens')
+const normalizeValueForBabel = require('../util/normalizeValueForBabel')
+
+const linter = new Linter()
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Lint JavaScript code inside Pug',
+      category: 'Stylistic Issues',
+      recommended: false,
+      url: docsUrl('eslint'),
+    },
+    schema: [
+      {
+        type: 'object',
+      },
+    ],
+  },
+
+  create: function (context) {
+    const lint = source => linter.verify(source, {
+      parserOptions: {
+        ecmaVersion: 2018,
+        sourceType: 'module',
+        ecmaFeatures: {
+          generators: false,
+          objectLiteralDuplicateProperties: false,
+        },
+      },
+      rules: {
+        ...context.options[0],
+      },
+    })
+
+    const getStringToLint = (token) => {
+      switch (token.type) {
+        case 'each':
+          return token.code
+
+        case 'attribute':
+        case 'if':
+        case 'else-if':
+        case 'code':
+          return token.val
+
+        default:
+          return null
+      }
+    }
+
+    return {
+      TaggedTemplateExpression: function (node) {
+        if (isReactPugReference(node)) {
+          const template = getTemplate(node)
+          const tokens = getTokens(template)
+          const lines = template.split('\n')
+
+          tokens.forEach((token) => {
+            const rawSource = getStringToLint(token)
+
+            if (rawSource) {
+              const isMultiline = token.loc.start.line !== token.loc.end.line
+              const extraIndent = isMultiline
+                ? token.loc.start.column - 1
+                : 0
+
+              const source = normalizeValueForBabel(rawSource, extraIndent)
+
+              const reports = lint(source)
+
+              if (reports.length) {
+                reports.forEach((report) => {
+                  const reportLine = token.loc.start.line - 1 + report.line - 1
+                  const reportSource = source.split('\n')[report.line - 1]
+                  const sourceColumnStart = lines[reportLine].indexOf(reportSource) - 1
+
+                  const startLine = report.line
+                  const endLine = report.endLine || startLine
+                  const startColumn = report.column
+                  const endColumn = report.endColumn || startColumn
+                  context.report({
+                    node,
+                    loc: buildLocation(
+                      [token.loc.start.line + startLine, sourceColumnStart + startColumn],
+                      [token.loc.start.line + endLine, sourceColumnStart + endColumn],
+                    ),
+                    message: report.message,
+                  })
+                })
+              }
+            }
+          })
+        }
+      },
+    }
+  },
+}

--- a/lib/rules/eslint.js
+++ b/lib/rules/eslint.js
@@ -91,16 +91,22 @@ module.exports = {
                   const sourceStartColumn = lines[reportLine].indexOf(reportSource) - 1
                   const sourceStartLine = node.loc.start.line + token.loc.start.line - 2
 
-                  const startLine = report.line
-                  const endLine = report.endLine || startLine
-                  const startColumn = report.column
-                  const endColumn = report.endColumn || startColumn
+                  const startLine = sourceStartLine + report.line
+                  const endLine = sourceStartLine + (report.endLine || report.line)
+
+                  const loc = report.endColumn
+                    ? buildLocation(
+                      [startLine, sourceStartColumn + report.column],
+                      [endLine, sourceStartColumn + report.endColumn],
+                    )
+                    : buildLocation(
+                      [startLine, sourceStartColumn + 1],
+                      [endLine, sourceStartColumn + reportSource.length + 1],
+                    )
+
                   context.report({
                     node,
-                    loc: buildLocation(
-                      [sourceStartLine + startLine, sourceStartColumn + startColumn],
-                      [sourceStartLine + endLine, sourceStartColumn + endColumn],
-                    ),
+                    loc,
                     message: report.message,
                   })
                 })

--- a/lib/rules/eslint.js
+++ b/lib/rules/eslint.js
@@ -56,6 +56,7 @@ module.exports = {
         case 'if':
         case 'else-if':
         case 'code':
+        case 'interpolated-code':
           return token.val
 
         default:

--- a/lib/rules/eslint.js
+++ b/lib/rules/eslint.js
@@ -44,6 +44,14 @@ module.exports = {
       },
       rules: {
         ...context.options[0],
+
+        // Controlled via other rules:
+        quotes: 'off',
+        'no-undef': 'off',
+
+        // To bypass literals and one-line source
+        'eol-last': 'off',
+        'no-unused-expressions': 'off',
       },
     })
 

--- a/lib/rules/eslint.js
+++ b/lib/rules/eslint.js
@@ -9,7 +9,7 @@ const { Linter } = require('eslint')
 const { isReactPugReference, buildLocation, docsUrl } = require('../util/eslint')
 const getTemplate = require('../util/getTemplate')
 const getTokens = require('../util/getTokens')
-const normalizeValueForBabel = require('../util/normalizeValueForBabel')
+const babelHelpers = require('../util/babel')
 
 const linter = new Linter()
 
@@ -92,14 +92,15 @@ module.exports = {
                 ? token.loc.start.column - 1
                 : 0
 
-              const source = normalizeValueForBabel(rawSource, extraIndent)
+              const alignedSource = babelHelpers.align(rawSource, extraIndent)
+              const parsableSource = babelHelpers.normalize(alignedSource)
 
-              const reports = lint(source)
+              const reports = lint(parsableSource)
 
               if (reports.length) {
                 reports.forEach((report) => {
                   const reportLine = token.loc.start.line - 1 + report.line - 1
-                  const reportSource = source.split('\n')[report.line - 1]
+                  const reportSource = alignedSource.split('\n')[report.line - 1]
                   const sourceStartColumn = lines[reportLine].indexOf(reportSource) - 1
                   const sourceStartLine = node.loc.start.line + token.loc.start.line - 2
 

--- a/lib/rules/eslint.js
+++ b/lib/rules/eslint.js
@@ -87,7 +87,8 @@ module.exports = {
                 reports.forEach((report) => {
                   const reportLine = token.loc.start.line - 1 + report.line - 1
                   const reportSource = source.split('\n')[report.line - 1]
-                  const sourceColumnStart = lines[reportLine].indexOf(reportSource) - 1
+                  const sourceStartColumn = lines[reportLine].indexOf(reportSource) - 1
+                  const sourceStartLine = node.loc.start.line + token.loc.start.line - 2
 
                   const startLine = report.line
                   const endLine = report.endLine || startLine
@@ -96,8 +97,8 @@ module.exports = {
                   context.report({
                     node,
                     loc: buildLocation(
-                      [token.loc.start.line + startLine, sourceColumnStart + startColumn],
-                      [token.loc.start.line + endLine, sourceColumnStart + endColumn],
+                      [sourceStartLine + startLine, sourceStartColumn + startColumn],
+                      [sourceStartLine + endLine, sourceStartColumn + endColumn],
                     ),
                     message: report.message,
                   })

--- a/lib/rules/eslint.js
+++ b/lib/rules/eslint.js
@@ -52,6 +52,10 @@ module.exports = {
         // To bypass literals and one-line source
         'eol-last': 'off',
         'no-unused-expressions': 'off',
+
+        // Unsupported features by pug
+        'prefer-template': 'off',
+        'prefer-destructuring': 'off',
       },
     })
 

--- a/lib/util/babel.js
+++ b/lib/util/babel.js
@@ -2,7 +2,7 @@ function doesStringLookLikeObject(string) {
   return /^\s*{/.test(string)
 }
 
-function normalizeValueForBabel(value) {
+function normalize(value) {
   // Just an object (like `{ first: 'one' }`) is not valid string to
   // be parsed by babel, so we need to wrap it by braces
   if (typeof value === 'string' && doesStringLookLikeObject(value)) {
@@ -14,15 +14,18 @@ function normalizeValueForBabel(value) {
   return String(value)
 }
 
-module.exports = (value, extraIndent = 0) => {
-  const normalizedValue = normalizeValueForBabel(value)
-
-  if (!extraIndent) {
-    return normalizedValue
+function align(value, indent = 0) {
+  if (!indent) {
+    return value
   }
 
-  return normalizedValue
+  return value
     .split('\n')
-    .map(line => line.replace(new RegExp(`^\\s{${extraIndent}}`), ''))
+    .map(line => line.replace(new RegExp(`^\\s{${indent}}`), ''))
     .join('\n')
+}
+
+module.exports = {
+  normalize,
+  align,
 }

--- a/lib/util/normalizeValueForBabel.js
+++ b/lib/util/normalizeValueForBabel.js
@@ -1,0 +1,28 @@
+function doesStringLookLikeObject(string) {
+  return /^\s*{/.test(string)
+}
+
+function normalizeValueForBabel(value) {
+  // Just an object (like `{ first: 'one' }`) is not valid string to
+  // be parsed by babel, so we need to wrap it by braces
+  if (typeof value === 'string' && doesStringLookLikeObject(value)) {
+    return `(${value})`
+  }
+
+  // Pug can return a boolean variable for attribute value, but babel
+  // can parses only strings
+  return String(value)
+}
+
+module.exports = (value, extraIndent = 0) => {
+  const normalizedValue = normalizeValueForBabel(value)
+
+  if (!extraIndent) {
+    return normalizedValue
+  }
+
+  return normalizedValue
+    .split('\n')
+    .map(line => line.replace(new RegExp(`^\\s{${extraIndent}}`), ''))
+    .join('\n')
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   ],
   "scripts": {
     "lint": "eslint ./",
-    "test": "mocha 'tests/**/*.js'"
+    "test": "mocha 'tests/**/*.js'",
+    "mocha": "mocha"
   },
   "dependencies": {
     "@babel/parser": "^7.3.2",

--- a/tests/lib/rules/eslint.js
+++ b/tests/lib/rules/eslint.js
@@ -178,14 +178,51 @@ const cases = [
       ],
     },
   },
+
+  {
+    name: 'Interpolation',
+    options: [{
+      'comma-spacing': 'error',
+      'object-curly-spacing': ['error', 'always'],
+    }],
+    valid: {
+      code: `
+        pug\`
+          div Text is #{test(one, two)}
+          div Text is #{test({ one: true })}
+        \`
+      `,
+    },
+    invalid: {
+      code: `
+        pug\`
+          div Text is #{test(one,two)}
+          div Text is #{test({one: true})}
+        \`
+      `,
+      errors: [
+        buildError([3, 33], [3, 34], 'A space is required after \',\'.'),
+        buildError([4, 30], [4, 30], 'A space is required after \'{\'.'),
+        buildError([4, 40], [4, 40], 'A space is required before \'}\'.'),
+      ],
+    },
+  },
 ]
 
-const extractCase = (items, type) => items.map(item => ({
+const extractCase = type => item => ({
   options: item.options || [],
   ...item[type],
-}))
+})
+
+const extractCases = type => (items) => {
+  if (items.some(item => item.only)) {
+    return items.filter(item => item.only).map(extractCase(type))
+  }
+
+  return items.map(extractCase(type))
+}
 
 ruleTester.run('rule "eslint"', rule, {
-  valid: extractCase(cases, 'valid'),
-  invalid: extractCase(cases, 'invalid'),
+  valid: extractCases('valid')(cases),
+  invalid: extractCases('invalid')(cases),
 })

--- a/tests/lib/rules/eslint.js
+++ b/tests/lib/rules/eslint.js
@@ -51,8 +51,8 @@ const cases = [
         \`
       `,
       errors: [
-        buildError([3, 27], [3, 27], 'Operator \'>\' must be spaced.'),
-        buildError([5, 32], [5, 32], 'Operator \'<\' must be spaced.'),
+        buildError([3, 14], [3, 29], 'Operator \'>\' must be spaced.'),
+        buildError([5, 19], [5, 36], 'Operator \'<\' must be spaced.'),
       ],
     },
   },
@@ -76,8 +76,8 @@ const cases = [
         \`
       `,
       errors: [
-        buildError([3, 26], [3, 26], 'A space is required after \'{\'.'),
-        buildError([3, 36], [3, 36], 'A space is required before \'}\'.'),
+        buildError([3, 13], [3, 37], 'A space is required after \'{\'.'),
+        buildError([3, 13], [3, 37], 'A space is required before \'}\'.'),
       ],
     },
   },
@@ -103,8 +103,8 @@ const cases = [
         \`
       `,
       errors: [
-        buildError([3, 25], [3, 25], 'A space is required after \'{\'.'),
-        buildError([3, 35], [3, 35], 'A space is required before \'}\'.'),
+        buildError([3, 24], [3, 37], 'A space is required after \'{\'.'),
+        buildError([3, 24], [3, 37], 'A space is required before \'}\'.'),
       ],
     },
   },
@@ -135,10 +135,10 @@ const cases = [
         \`
       `,
       errors: [
+        buildError([6, 26], [6, 67], 'Multiple spaces found before \'four\'.'),
+        buildError([6, 26], [6, 67], 'Multiple spaces found before \'five\'.'),
         buildError([6, 41], [6, 42], 'A space is required after \',\'.'),
         buildError([6, 45], [6, 46], 'A space is required after \',\'.'),
-        buildError([6, 54], [6, 54], 'Multiple spaces found before \'four\'.'),
-        buildError([6, 62], [6, 62], 'Multiple spaces found before \'five\'.'),
       ],
     },
   },
@@ -174,7 +174,7 @@ const cases = [
       `,
       errors: [
         buildError([6, 13], [6, 16], 'Expected indentation of 2 spaces but found 3.'),
-        buildError([6, 31], [6, 31], 'Missing trailing comma.'),
+        buildError([6, 13], [6, 31], 'Missing trailing comma.'),
       ],
     },
   },
@@ -202,8 +202,8 @@ const cases = [
       `,
       errors: [
         buildError([3, 33], [3, 34], 'A space is required after \',\'.'),
-        buildError([4, 30], [4, 30], 'A space is required after \'{\'.'),
-        buildError([4, 40], [4, 40], 'A space is required before \'}\'.'),
+        buildError([4, 25], [4, 42], 'A space is required after \'{\'.'),
+        buildError([4, 25], [4, 42], 'A space is required before \'}\'.'),
       ],
     },
   },

--- a/tests/lib/rules/eslint.js
+++ b/tests/lib/rules/eslint.js
@@ -117,6 +117,9 @@ const cases = [
     }],
     valid: {
       code: `
+        const getValueFor = () =>
+          null
+
         pug\`
           div(data-value=getValueFor(one, two, three))
         \`
@@ -124,15 +127,18 @@ const cases = [
     },
     invalid: {
       code: `
+        const getValueFor = () =>
+          null
+
         pug\`
           div(data-value=getValueFor(one,two,three,  four,   five))
         \`
       `,
       errors: [
-        buildError([3, 41], [3, 42], 'A space is required after \',\'.'),
-        buildError([3, 45], [3, 46], 'A space is required after \',\'.'),
-        buildError([3, 54], [3, 54], 'Multiple spaces found before \'four\'.'),
-        buildError([3, 62], [3, 62], 'Multiple spaces found before \'five\'.'),
+        buildError([6, 41], [6, 42], 'A space is required after \',\'.'),
+        buildError([6, 45], [6, 46], 'A space is required after \',\'.'),
+        buildError([6, 54], [6, 54], 'Multiple spaces found before \'four\'.'),
+        buildError([6, 62], [6, 62], 'Multiple spaces found before \'five\'.'),
       ],
     },
   },

--- a/tests/lib/rules/eslint.js
+++ b/tests/lib/rules/eslint.js
@@ -1,0 +1,185 @@
+/**
+ * @fileoverview Tests for uses-react
+ * @author Eugene Zhlobo
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const eslint = require('eslint')
+const buildError = require('../../../lib/util/testBuildError')
+
+const { RuleTester } = eslint
+
+const rule = require('../../../lib/rules/eslint')
+
+const parserOptions = {
+  ecmaVersion: 8,
+  sourceType: 'module',
+}
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({ parserOptions })
+
+const cases = [
+  {
+    name: 'if, if-else',
+    options: [{
+      'space-infix-ops': 'error',
+    }],
+    valid: {
+      code: `
+        pug\`
+          if this.method() > 1
+            div big
+          else if this.method() < -1
+            div small
+        \`
+      `,
+    },
+    invalid: {
+      code: `
+        pug\`
+          if this.method()>1
+            div big
+          else if this.method()< -1
+            div small
+        \`
+      `,
+      errors: [
+        buildError([3, 27], [3, 27], 'Operator \'>\' must be spaced.'),
+        buildError([5, 32], [5, 32], 'Operator \'<\' must be spaced.'),
+      ],
+    },
+  },
+
+  {
+    name: 'Code',
+    options: [{
+      'object-curly-spacing': ['error', 'always'],
+    }],
+    valid: {
+      code: `
+        pug\`
+          - const test = { one: true }
+        \`
+      `,
+    },
+    invalid: {
+      code: `
+        pug\`
+          - const test = {one: true}
+        \`
+      `,
+      errors: [
+        buildError([3, 26], [3, 26], 'A space is required after \'{\'.'),
+        buildError([3, 36], [3, 36], 'A space is required before \'}\'.'),
+      ],
+    },
+  },
+
+  {
+    name: 'Each',
+    options: [{
+      'object-curly-spacing': ['error', 'always'],
+    }],
+    valid: {
+      code: `
+        pug\`
+          each item in [{ one: true }]
+            = item
+        \`
+      `,
+    },
+    invalid: {
+      code: `
+        pug\`
+          each item in [{one: true}]
+            = item
+        \`
+      `,
+      errors: [
+        buildError([3, 25], [3, 25], 'A space is required after \'{\'.'),
+        buildError([3, 35], [3, 35], 'A space is required before \'}\'.'),
+      ],
+    },
+  },
+
+  {
+    name: 'One line attribute',
+    options: [{
+      'comma-spacing': 'error',
+      'no-multi-spaces': 'error',
+    }],
+    valid: {
+      code: `
+        pug\`
+          div(data-value=getValueFor(one, two, three))
+        \`
+      `,
+    },
+    invalid: {
+      code: `
+        pug\`
+          div(data-value=getValueFor(one,two,three,  four,   five))
+        \`
+      `,
+      errors: [
+        buildError([3, 41], [3, 42], 'A space is required after \',\'.'),
+        buildError([3, 45], [3, 46], 'A space is required after \',\'.'),
+        buildError([3, 54], [3, 54], 'Multiple spaces found before \'four\'.'),
+        buildError([3, 62], [3, 62], 'Multiple spaces found before \'five\'.'),
+      ],
+    },
+  },
+
+  {
+    name: 'Multi line attribute',
+    options: [{
+      'comma-dangle': ['error', 'always-multiline'],
+      indent: ['error', 2],
+    }],
+    valid: {
+      code: `
+        pug\`
+          div(
+            className={
+              test: true,
+              selected: false,
+            }
+          )
+        \`
+      `,
+    },
+    invalid: {
+      code: `
+        pug\`
+          div(
+            className={
+              test: true,
+               selected: false
+            }
+          )
+        \`
+      `,
+      errors: [
+        buildError([6, 13], [6, 16], 'Expected indentation of 2 spaces but found 3.'),
+        buildError([6, 31], [6, 31], 'Missing trailing comma.'),
+      ],
+    },
+  },
+]
+
+const extractCase = (items, type) => items.map(item => ({
+  options: item.options || [],
+  ...item[type],
+}))
+
+ruleTester.run('rule "eslint"', rule, {
+  valid: extractCase(cases, 'valid'),
+  invalid: extractCase(cases, 'invalid'),
+})

--- a/tests/lib/rules/eslint.js
+++ b/tests/lib/rules/eslint.js
@@ -146,6 +146,7 @@ const cases = [
   {
     name: 'Multi line attribute',
     options: [{
+      'object-curly-spacing': ['error', 'always'],
       'comma-dangle': ['error', 'always-multiline'],
       indent: ['error', 2],
     }],
@@ -153,6 +154,8 @@ const cases = [
       code: `
         pug\`
           div(
+
+            data={ bool: true }
             className={
               test: true,
               selected: false,
@@ -165,6 +168,8 @@ const cases = [
       code: `
         pug\`
           div(
+
+            data={bool: true}
             className={
               test: true,
                selected: false
@@ -173,8 +178,10 @@ const cases = [
         \`
       `,
       errors: [
-        buildError([6, 13], [6, 16], 'Expected indentation of 2 spaces but found 3.'),
-        buildError([6, 13], [6, 31], 'Missing trailing comma.'),
+        buildError([5, 18], [5, 30], 'A space is required after \'{\'.'),
+        buildError([5, 18], [5, 30], 'A space is required before \'}\'.'),
+        buildError([8, 13], [8, 16], 'Expected indentation of 2 spaces but found 3.'),
+        buildError([8, 13], [8, 31], 'Missing trailing comma.'),
       ],
     },
   },


### PR DESCRIPTION
Initial request: #61 

## Interface

```js
{
  rules: {
    'react-pug/eslint': ['error', {
      // Rules from eslint, these two for instance:
      'no-multi-spaces': 'error',
      'indent': ['error', 2],
    }],
  }
}
```

## Checklist

- [x] Allow running eslint for JavaScript in Pug
- [x] Improve LOCs in reports