### PR TITLE
Fix using iterations for each without used props inside

### DIFF
--- a/lib/util/getUsedVariablesInPug.js
+++ b/lib/util/getUsedVariablesInPug.js
@@ -135,9 +135,11 @@ const getUsedVariablesInPug = (template = '') => {
         },
       })
 
-      let variablesInScope = []
+      const lastAddedVariable = usedVariables[usedVariables.length - 1]
 
-      if (token.type === 'each') {
+      // If we define a scope with a variable connected to props in that definition,
+      // we also mark all vars in that scope as used
+      if (token.type === 'each' && lastAddedVariable) {
         const getLastTokenInScope = (all, start) => {
           const startIndex = all.findIndex(item => item === start)
           const lastToken = all.slice(startIndex).find(item => item.type === 'outdent' && item.loc.end.column <= start.loc.start.column)
@@ -151,7 +153,7 @@ const getUsedVariablesInPug = (template = '') => {
         const bodyLines = [''].concat(lines.slice(startToken.loc.start.line, endToken.loc.end.line - 1))
         const body = bodyLines.join('\n')
 
-        variablesInScope = getUsedVariablesInPug(body)
+        const variablesInScope = getUsedVariablesInPug(body)
           .filter(item => item.allNames.length > 1 || item.extra.isSpreadElement === true)
           .map(item => ({
             ...item,
@@ -169,16 +171,14 @@ const getUsedVariablesInPug = (template = '') => {
               ? ['__COMPUTED_PROP__', ...item.allNames.slice(1)]
               : item.allNames,
           }))
-      }
 
-      const lastAddedVariable = usedVariables[usedVariables.length - 1]
-
-      variablesInScope.forEach((item) => {
-        usedVariables.push({
-          ...item,
-          allNames: [...lastAddedVariable.allNames, ...item.allNames],
+        variablesInScope.forEach((item) => {
+          usedVariables.push({
+            ...item,
+            allNames: [...lastAddedVariable.allNames, ...item.allNames],
+          })
         })
-      })
+      }
     })
 
   return usedVariables

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -576,6 +576,19 @@ const cases = [
           }
         `,
       },
+      {
+        code: `
+          function Component() {
+            const list = []
+
+            return pug\`
+              each item in list
+                div(key=item.id)
+                  = item.test
+            \`
+          }
+        `,
+      },
     ],
     invalid: [
       {

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -642,7 +642,6 @@ const cases = [
         ],
       },
       {
-        only: true,
         code: `
           function Component(props) {
             const id = true


### PR DESCRIPTION
Test case:

```js
function Component() {
  const list = []

  return pug`
    each item in list
      div(key=item.id)= item.test
  `
}
```

Here is a programmatic issue, we were trying to attach `item.id` and `item.test` to props, but that iteration does not relate to props at all.