### PR TITLE
Support spreading for nested props

### DIFF
--- a/lib/util/detectComponents.js
+++ b/lib/util/detectComponents.js
@@ -57,6 +57,7 @@ module.exports = rule => Components.detect((context, components, utils) => {
           node: {
             loc: variable.loc,
           },
+          extra: variable.extra || {},
         })
       })
 

--- a/lib/util/eslint-plugin-react.utils.js
+++ b/lib/util/eslint-plugin-react.utils.js
@@ -124,6 +124,7 @@ module.exports.createReportUnusedPropTypes = (context, components, configuration
 
   function isPropUsed(node, prop) {
     const usedPropTypes = node.usedPropTypes || [];
+    // @TODO: Here we will need to understand whether the prop is within a spreading
     for (let i = 0, l = usedPropTypes.length; i < l; i++) {
       const usedProp = usedPropTypes[i];
       if (

--- a/lib/util/eslint-plugin-react.utils.js
+++ b/lib/util/eslint-plugin-react.utils.js
@@ -122,15 +122,15 @@ module.exports.createReportUndeclaredPropTypes = (context, components, configura
 module.exports.createReportUnusedPropTypes = (context, components, configuration) => {
   const UNUSED_MESSAGE = '\'{{name}}\' PropType is defined but prop is never used';
 
-  function isPropUsed(node, prop) {
+  function isPropUsed(node, prop, parentProp) {
     const usedPropTypes = node.usedPropTypes || [];
-    // @TODO: Here we will need to understand whether the prop is within a spreading
     for (let i = 0, l = usedPropTypes.length; i < l; i++) {
       const usedProp = usedPropTypes[i];
       if (
         prop.type === 'shape' ||
         prop.name === '__ANY_KEY__' ||
-        usedProp.name === prop.name
+        usedProp.name === prop.name ||
+        (usedProp.name === parentProp.fullName && usedProp.extra && usedProp.extra.isSpreadElement)
       ) {
         return true;
       }
@@ -144,7 +144,7 @@ module.exports.createReportUnusedPropTypes = (context, components, configuration
    * @param {Object} component The component to process
    * @param {ASTNode[]|true} props List of props to validate
    */
-  function reportUnusedPropType(component, props) {
+  function reportUnusedPropType(component, props, parentProp = {}) {
     // Skip props that check instances
     if (props === true) {
       return;
@@ -161,7 +161,7 @@ module.exports.createReportUnusedPropTypes = (context, components, configuration
         return;
       }
 
-      if (prop.node && !isPropUsed(component, prop)) {
+      if (prop.node && !isPropUsed(component, prop, parentProp)) {
         context.report({
           node: prop.node.value || prop.node,
           message: UNUSED_MESSAGE,
@@ -172,7 +172,7 @@ module.exports.createReportUnusedPropTypes = (context, components, configuration
       }
 
       if (prop.children) {
-        reportUnusedPropType(component, prop.children);
+        reportUnusedPropType(component, prop.children, prop);
       }
     });
   }

--- a/lib/util/getUsedVariablesInPug.js
+++ b/lib/util/getUsedVariablesInPug.js
@@ -92,6 +92,9 @@ const getUsedVariablesInPug = (template = '') => {
         }
       }
 
+      // @TODO: We need to understand whether the prop used within spreading or not better,
+      // for now when we see `...props.test` we mark both `props` and `test` with spreading,
+      // while we should mark only `test`
       traverse(ast, {
         Identifier(path) {
           const loc = buildLocation(

--- a/lib/util/getUsedVariablesInPug.js
+++ b/lib/util/getUsedVariablesInPug.js
@@ -176,9 +176,13 @@ const getUsedVariablesInPug = (template = '') => {
           }))
 
         variablesInScope.forEach((item) => {
+          const allNames = item.allNames[0] === '__COMPUTED_PROP__' && item.allNames.length > 1
+            ? lastAddedVariable.allNames.concat(item.allNames)
+            : item.allNames
+
           usedVariables.push({
             ...item,
-            allNames: [...lastAddedVariable.allNames, ...item.allNames],
+            allNames,
           })
         })
       }

--- a/lib/util/getUsedVariablesInPug.js
+++ b/lib/util/getUsedVariablesInPug.js
@@ -91,10 +91,6 @@ const getUsedVariablesInPug = (template = '') => {
           codeStartsAt = relatedLine.indexOf(codeFragment)
         }
       }
-
-      // @TODO: We need to understand whether the prop used within spreading or not better,
-      // for now when we see `...props.test` we mark both `props` and `test` with spreading,
-      // while we should mark only `test`
       traverse(ast, {
         Identifier(path) {
           const loc = buildLocation(
@@ -105,17 +101,19 @@ const getUsedVariablesInPug = (template = '') => {
           )
 
           if (path.parentPath.isMemberExpression()) {
+            const isProperty = path.key === 'property'
             usedVariables.push(buildVariable(
               path.node.name,
               getFullName(path),
               loc,
+              { isSpreadElement: isSpreadElement && isProperty },
             ))
           } else if (isSpreadElement) {
             usedVariables.push(buildVariable(
               path.node.name,
               getFullName(path),
               loc,
-              { isSpreadElement },
+              { isSpreadElement: true },
             ))
           }
         },
@@ -128,11 +126,13 @@ const getUsedVariablesInPug = (template = '') => {
               variable.loc.end.line,
               codeStartsAt + path.node.loc.start.column + path.node.extra.raw.length,
             )
+            const isProperty = path.key === 'property'
 
             usedVariables.push(buildVariable(
               path.node.value,
               getFullName(path),
               loc,
+              { isSpreadElement: isSpreadElement && isProperty },
             ))
           }
         },

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -457,6 +457,7 @@ const cases = [
         ],
       },
       {
+        only: true,
         code: `
           function Component(props) {
             return pug\`
@@ -586,6 +587,21 @@ const cases = [
                 div(key=item.id)
                   = item.test
             \`
+          }
+        `,
+      },
+      {
+        only: true,
+        code: `
+          const Component = props => pug\`
+            //-= props.test
+            div(...props.style)
+          \`
+          Component.propTypes = {
+            // test: PropTypes.string,
+            style: PropTypes.shape({
+              anything: PropTypes.string,
+            })
           }
         `,
       },

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -457,7 +457,6 @@ const cases = [
         ],
       },
       {
-        only: true,
         code: `
           function Component(props) {
             return pug\`
@@ -591,17 +590,16 @@ const cases = [
         `,
       },
       {
-        only: true,
         code: `
           const Component = props => pug\`
-            //-= props.test
+            = props.test
             div(...props.style)
           \`
           Component.propTypes = {
-            // test: PropTypes.string,
+            test: PropTypes.string,
             style: PropTypes.shape({
-              anything: PropTypes.string,
-            })
+              one: PropTypes.string,
+            }),
           }
         `,
       },
@@ -692,6 +690,21 @@ const cases = [
         errors: [
           buildError([8, 32], [8, 34], buildMissingMessage('list[].id')),
           buildError([9, 28], [9, 32], buildMissingMessage('list[].test')),
+        ],
+      },
+      {
+        code: `
+          const Component = props => pug\`
+            = props['style']
+          \`
+          Component.propTypes = {
+            style: PropTypes.shape({
+              one: PropTypes.string,
+            }),
+          }
+        `,
+        errors: [
+          buildError([7, 20], [7, 36], buildUnusedMessage('style.one')),
         ],
       },
     ],

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -707,6 +707,69 @@ const cases = [
           buildError([7, 20], [7, 36], buildUnusedMessage('style.one')),
         ],
       },
+      {
+        code: `
+          const Component = props => pug\`
+            each item in props.list
+              div(key=item.id)
+                div(
+                  ...item
+                )
+          \`
+          Component.propTypes = {
+            list: PropTypes.arrayOf(PropTypes.shape({
+              anything: PropTypes.string,
+            })),
+          }
+        `,
+        errors: [
+          buildError([4, 28], [4, 30], buildMissingMessage('list[].id')),
+          buildError([11, 25], [11, 41], buildUnusedMessage('list.*.anything')),
+        ],
+      },
+    ],
+  },
+
+  {
+    name: 'Used main props inside iterations',
+    valid: [
+      {
+        code: `
+          const Component = props => pug\`
+            each item in props.list
+              div(key=item.id)
+                div(
+                  ...item
+                  another=props.test
+                )
+          \`
+          Component.propTypes = {
+            list: PropTypes.arrayOf(PropTypes.shape({
+              id: PropTypes.string,
+            })),
+            test: PropTypes.bool,
+          }
+        `,
+      },
+    ],
+    invalid: [
+      {
+        code: `
+          const Component = props => pug\`
+            each item in props.list
+              div(key=item.id)
+                div(
+                  ...item
+                  another=props.test
+                )
+          \`
+        `,
+        errors: [
+          buildError([3, 32], [3, 36], buildMissingMessage('list')),
+          buildError([4, 28], [4, 30], buildMissingMessage('list[].id')),
+          buildError([7, 33], [7, 37], buildMissingMessage('test')),
+        ],
+      },
     ],
   },
 ]


### PR DESCRIPTION
Add supporting of nested spreading of props (everything defined inside should be marked as used in props definitions). For example the following code should not trigger any warning/error in eslint

```jsx
const Component = props => pug`
  div(...props.style)
`
Component.propTypes = {
  style: PropTypes.shape({
    anything: PropTypes.string,
  })
}
```